### PR TITLE
ICM-86 Added code coverage reporting support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,7 @@ jdk:
 
 before_install:
   - chmod +x gradlew
+  - pip install --user codecov
+
+after_success:
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,9 @@ before_install:
   - chmod +x gradlew
   - pip install --user codecov
 
+script:
+  - ./gradlew --info check jacocoTestReport
+
 after_success:
+  - ./gradlew jacocoTestReport
   - codecov

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # vertx-guice
 Enable Verticle dependency injection in Vert.x using Guice. 
 
+[![Code Coverage](https://img.shields.io/codecov/c/github/intappx/vertx-guice.svg)](https://codecov.io/github/intappx/vertx-guice)
+
 It is designed to use single injector per Vert.x instance.
 It means that `Singleton' scope is supported and works as expected. This was the main reason to implement this library instead of using [vertx-guice](https://github.com/englishtown/vertx-guice) library from English Town.
 

--- a/vertx-guice/build.gradle
+++ b/vertx-guice/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'jacoco'
 }
 
 //noinspection GroovyUnusedAssignment
@@ -22,4 +23,10 @@ dependencies {
 
     testCompile "io.vertx:vertx-core:$vertxVersion:tests"
     testCompile "io.vertx:vertx-rx-java:$vertxVersion"
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
 }


### PR DESCRIPTION
Performed the following:
1) Added support for Codecov service
2) Added logic to explicitly generate code coverage reports during CI build.
3) Added budget to Readme file which shows code coverage status of the master branch.

ICM-86 "Extend vertx-guice to use single injector for all verticles".